### PR TITLE
商品購入確認ページとトップページの修正

### DIFF
--- a/app/views/funato-newest/index.html.haml
+++ b/app/views/funato-newest/index.html.haml
@@ -1,0 +1,273 @@
+.content
+  .top__header__area
+    .top__header__area__carousel
+      = image_tag 'top-banner-camp.jpg', class:'top__header__area__carousel-img'
+    .top__header__area__popularity
+      %h2.top__header__area__popularity-headline 人気のカテゴリー
+    %ul.top__header__area__popularity__category
+      %li レディース
+      %li メンズ
+      %li 家電・スマホ・カメラ
+      %li おもちゃ・ホビー・グッズ
+  %section.new__items
+    .new__items-genre
+      %h3
+        レディース新着アイテム
+      %a{:href => "###"}
+        %span.new__items-more もっと見る
+        %i.fas.fa-angle-right
+  %section.new__items
+    .new__items__container
+      %a{:href => "###"}
+        .new__items__container__box
+          %figure
+            = image_tag 'item04.jpg', class:'new__items__container__box-item_phot'
+            %p.new__items__container__box-price ¥2,500
+          .new__items__container__box__item_body
+            %h3 ルイヴィトン ダミエ リビラ
+      %a{:href => "###"}
+        .new__items__container__box
+          %figure
+            = image_tag 'item04.jpg', class:'new__items__container__box-item_phot'
+            %p.new__items__container__box-price ¥2,500
+          .new__items__container__box__item_body
+            %h3 ルイヴィトン ダミエ リビラ
+      %a{:href => "###"}
+        .new__items__container__box
+          %figure
+            = image_tag 'item04.jpg', class:'new__items__container__box-item_phot'
+            %p.new__items__container__box-price ¥2,500
+          .new__items__container__box__item_body
+            %h3 ルイヴィトン ダミエ リビラ
+      %a{:href => "###"}
+        .new__items__container__box
+          %figure
+            = image_tag 'item04.jpg', class:'new__items__container__box-item_phot'
+            %p.new__items__container__box-price ¥2,500
+          .new__items__container__box__item_body
+            %h3 ルイヴィトン ダミエ リビラ
+      %a{:href => "###"}
+        .new__items__container__box
+          %figure
+            = image_tag 'item04.jpg', class:'new__items__container__box-item_phot'
+            %p.new__items__container__box-price ¥2,500
+          .new__items__container__box__item_body
+            %h3 ルイヴィトン ダミエ リビラ
+      %a{:href => "###"}
+        .new__items__container__box
+          %figure
+            = image_tag 'item04.jpg', class:'new__items__container__box-item_phot'
+            %p.new__items__container__box-price ¥2,500
+          .new__items__container__box__item_body
+            %h3 ルイヴィトン ダミエ リビラ
+      %a{:href => "###"}
+        .new__items__container__box
+          %figure
+            = image_tag 'item04.jpg', class:'new__items__container__box-item_phot'
+            %p.new__items__container__box-price ¥2,500
+          .new__items__container__box__item_body
+            %h3 ルイヴィトン ダミエ リビラ
+      %a{:href => "###"}
+        .new__items__container__box
+          %figure
+            = image_tag 'item04.jpg', class:'new__items__container__box-item_phot'
+            %p.new__items__container__box-price ¥2,500
+          .new__items__container__box__item_body
+            %h3 ルイヴィトン ダミエ リビラ
+      %a{:href => "###"}
+        .new__items__container__box
+          %figure
+            = image_tag 'item04.jpg', class:'new__items__container__box-item_phot'
+            %p.new__items__container__box-price ¥2,500
+          .new__items__container__box__item_body
+            %h3 ルイヴィトン ダミエ リビラ
+      %a{:href => "###"}
+        .new__items__container__box
+          %figure
+            = image_tag 'item04.jpg', class:'new__items__container__box-item_phot'
+            %p.new__items__container__box-price ¥2,500
+          .new__items__container__box__item_body
+            %h3 ルイヴィトン ダミエ リビラ
+  %section.new__items
+    .new__items-genre
+      %h3
+        メンズ新着アイテム
+      %a{:href => "###"}
+        %span.new__items-more もっと見る
+        %i.fas.fa-angle-right
+  %section.new__items
+    .new__items__container
+      %a{:href => "###"}
+        .new__items__container__box
+          %figure
+            = image_tag 'mens01.jpg', class:'new__items__container__box-item_phot'
+            %p.new__items__container__box-price ¥5,500
+          .new__items__container__box__item_body
+            %h3 kutir black テーラードブルゾン
+      %a{:href => "###"}
+        .new__items__container__box
+          %figure
+            = image_tag 'mens01.jpg', class:'new__items__container__box-item_phot'
+            %p.new__items__container__box-price ¥5,500
+          .new__items__container__box__item_body
+            %h3 kutir black テーラードブルゾン
+      %a{:href => "###"}
+        .new__items__container__box
+          %figure
+            = image_tag 'mens01.jpg', class:'new__items__container__box-item_phot'
+            %p.new__items__container__box-price ¥5,500
+          .new__items__container__box__item_body
+            %h3 kutir black テーラードブルゾン
+      %a{:href => "###"}
+        .new__items__container__box
+          %figure
+            = image_tag 'mens01.jpg', class:'new__items__container__box-item_phot'
+            %p.new__items__container__box-price ¥5,500
+          .new__items__container__box__item_body
+            %h3 kutir black テーラードブルゾン
+      %a{:href => "###"}
+        .new__items__container__box
+          %figure
+            = image_tag 'mens01.jpg', class:'new__items__container__box-item_phot'
+            %p.new__items__container__box-price ¥5,500
+          .new__items__container__box__item_body
+            %h3 kutir black テーラードブルゾン
+      %a{:href => "###"}
+        .new__items__container__box
+          %figure
+            = image_tag 'mens01.jpg', class:'new__items__container__box-item_phot'
+            %p.new__items__container__box-price ¥5,500
+          .new__items__container__box__item_body
+            %h3 kutir black テーラードブルゾン
+      %a{:href => "###"}
+        .new__items__container__box
+          %figure
+            = image_tag 'mens01.jpg', class:'new__items__container__box-item_phot'
+            %p.new__items__container__box-price ¥5,500
+          .new__items__container__box__item_body
+            %h3 kutir black テーラードブルゾン
+      %a{:href => "###"}
+        .new__items__container__box
+          %figure
+            = image_tag 'mens01.jpg', class:'new__items__container__box-item_phot'
+            %p.new__items__container__box-price ¥5,500
+          .new__items__container__box__item_body
+            %h3 kutir black テーラードブルゾン
+      %a{:href => "###"}
+        .new__items__container__box
+          %figure
+            = image_tag 'mens01.jpg', class:'new__items__container__box-item_phot'
+            %p.new__items__container__box-price ¥5,500
+          .new__items__container__box__item_body
+            %h3 kutir black テーラードブルゾン
+      %a{:href => "###"}
+        .new__items__container__box
+          %figure
+            = image_tag 'mens01.jpg', class:'new__items__container__box-item_phot'
+            %p.new__items__container__box-price ¥5,500
+          .new__items__container__box__item_body
+            %h3 kutir black テーラードブルゾン
+  %section.new__items
+    .new__items-genre
+      %h3
+        家電・スマホ・カメラ新着アイテム
+      %a{:href => "###"}
+        %span.new__items-more もっと見る
+        %i.fas.fa-angle-right
+  %section.new__items
+    .new__items__container
+      %a{:href => "###"}
+        .new__items__container__box
+          %figure
+            = image_tag 'iphonese.jpg', class:'new__items__container__box-item_phot'
+            %p.new__items__container__box-price ¥12,500
+          .new__items__container__box__item_body
+            %h3 iPhone SE Space Gray 32 GB（中古）
+  %section.new__items
+    .new__items-genre
+      %h3
+        おもちゃ・ホビー・グッズ新着アイテム
+      %a{:href => "###"}
+        %span.new__items-more もっと見る
+        %i.fas.fa-angle-right
+  %section.new__items
+    .new__items__container
+      %a{:href => "###"}
+        .new__items__container__box
+          %figure
+            = image_tag 'slime.jpg', class:'new__items__container__box-item_phot'
+            %p.new__items__container__box-price ¥3,000
+          .new__items__container__box__item_body
+            %h3 スライムぬいぐるみセット
+  .top__header__area
+    .top__header__area__popularity
+      %h2.top__header__area__popularity-headline 人気のブランド
+    %ul.top__header__area__popularity__category
+      %li シャネル
+      %li ルイビトン
+      %li ポーター
+      %li アディダス
+  %section.new__items
+    .new__items-genre
+      %h3
+        シャネル新着アイテム
+      %a{:href => "###"}
+        %span.new__items-more もっと見る
+        %i.fas.fa-angle-right
+  %section.new__items
+    .new__items__container
+      %a{:href => "###"}
+        .new__items__container__box
+          %figure
+            = image_tag 'CHANEL.jpg', class:'new__items__container__box-item_phot'
+            %p.new__items__container__box-price ¥9,000
+          .new__items__container__box__item_body
+            %h3 1番人気 新品未開封！大人気 CHANEL チャンス 100ml
+  %section.new__items
+    .new__items-genre
+      %h3
+        ルイヴィトン新着アイテム
+      %a{:href => "###"}
+        %span.new__items-more もっと見る
+        %i.fas.fa-angle-right
+  %section.new__items
+    .new__items__container
+      %a{:href => "###"}
+        .new__items__container__box
+          %figure
+            = image_tag 'luisvuitton.jpg', class:'new__items__container__box-item_phot'
+            %p.new__items__container__box-price ¥6,900
+          .new__items__container__box__item_body
+            %h3 ルイヴィトン ミュール サンダル パンプス ヒール 35
+  %section.new__items
+    .new__items-genre
+      %h3
+        ポーター新着アイテム
+      %a{:href => "###"}
+        %span.new__items-more もっと見る
+        %i.fas.fa-angle-right
+  %section.new__items
+    .new__items__container
+      %a{:href => "###"}
+        .new__items__container__box
+          %figure
+            = image_tag 'porter.jpg', class:'new__items__container__box-item_phot'
+            %p.new__items__container__box-price ¥16,000
+          .new__items__container__box__item_body
+            %h3 ポーター2wayトートバッグ／タンゴブラックシリーズ
+  %section.new__items
+    .new__items-genre
+      %h3
+        アディダス新着アイテム
+      %a{:href => "###"}
+        %span.new__items-more もっと見る
+        %i.fas.fa-angle-right
+  %section.new__items
+    .new__items__container
+      %a{:href => "###"}
+        .new__items__container__box
+          %figure
+            = image_tag 'adidas.jpg', class:'new__items__container__box-item_phot'
+            %p.new__items__container__box-price ¥17,500
+          .new__items__container__box__item_body
+            %h3 90's adidas ADVENTURE デナリジャケット デサント製

--- a/app/views/funato-newest/purchase_confirmation.html.haml
+++ b/app/views/funato-newest/purchase_confirmation.html.haml
@@ -1,0 +1,46 @@
+.purchase_confirmation__contents
+  %section.purchase_confirmation__contents__area
+    %h2.purchase_confirmation__contents__area-head_title 購入内容の確認
+  %section.purchase_confirmation__contents__buy
+    %section.purchase_confirmation__contents__buy__inner
+      %h3
+        = image_tag 'item04.jpg', class:'purchase_confirmation__contents__buy__inner-item_img'
+      %p.purchase_confirmation__contents__buy__inner-item_name ルイヴィトン ハンドバッグ
+      .purchase_confirmation__contents__buy__inner__buying-form
+        %p.purchase_confirmation__contents__buy__inner__buying-form-price ¥6,500
+        %span.purchase_confirmation__contents__buy__inner__buying-form-delivery-fee 送料込み
+        %ul.purchase_confirmation__contents__buy__inner__buying-form__pointbox
+          %li.purchase_confirmation__contents__buy__inner__buying-form-pointbox ポイントはありません
+        %ul.purchase_confirmation__contents__buy__inner__buying-form__payment
+          %li.purchase_confirmation__contents__buy__inner__buying-form__payment-pay_amount
+            %div 支払い金額
+            .purchase_confirmation__contents__buy__inner__buying-form__payment-pay_amount-price_cell ¥6,500
+        %p.purchase_confirmation__contents__buy__inner__buying-form-error_text この商品はゆうゆうメルカリ便を利用しているため、アプリからのみ購入できます。
+        %button.purchase_confirmation__contents__buy__inner__buying-form-btn{:type => "submit"} 購入する
+        %p.purchase_confirmation__contents__buy__inner__buying-form-apprecommend アプリをお持ちでない方は以下よりインストールしてご利用いただけます。
+        .purchase_confirmation__contents__buy__inner__buying-form-app-icon
+          %a{:href => "###"}
+            = image_tag 'download-on-the-app-store-apple.svg', class:'purchase_confirmation__contents__buy__inner__buying-form-app-icon-size-apple'
+          %a{:href => "###"}
+            = image_tag 'google-play-download-android-app.svg', class:'purchase_confirmation__contents__buy__inner__buying-form-app-icon-size-google'
+  %section.purchase_confirmation__contents__buy
+    .purchase_confirmation__contents__buyer_info
+      %h3 配送先
+      %address.purchase_confirmation__contents__buyer_info-add
+        〒000-0000
+        %br/
+        大阪府 大阪市中央区中市浜 4-2-2
+        %br/
+        メルカリ 花子
+      %a.purchase_confirmation__contents__buyer_info-change{:href => "###"}
+        %span 変更する
+        %i.fas.fa-angle-right
+  %section.purchase_confirmation__contents__buy
+    .purchase_confirmation__contents__buyer_info
+      %h3 支払い方法
+      %address.purchase_confirmation__contents__buyer_info-payway
+        %br/
+        \/
+      %a.purchase_confirmation__contents__buyer_info-change{:href => "###"}
+        %span 変更する
+        %i.fas.fa-angle-right

--- a/app/views/funato-newest/purchase_confirmation.scss
+++ b/app/views/funato-newest/purchase_confirmation.scss
@@ -1,0 +1,215 @@
+.purchase_confirmation__top{
+  position: fixed;
+  width: 100%;
+  height: 128px;
+  margin: 0 auto;
+  text-align: center;
+  background-color: #eee;
+
+  &-logo{
+		width: 185px;
+    height: 49px;
+  }
+
+  h1{
+    margin: 40px 0 0;
+  }
+
+  a{
+    text-decoration: none;
+  }
+  a:hover{
+    text-decoration: none;
+    opacity: 0.8;
+  }
+}
+
+.purchase_confirmation__contents{
+  width: 100%;
+  height: 100%;
+  margin-top: 128px;
+  padding: 0;
+
+  &__area{
+    width: 700px;
+    margin: 0 auto;
+    background-color: #fff;
+    text-align: center;
+  
+      &-head_title{
+        padding:16px;
+        font-size: 22px;
+        line-height: 1.5;
+      }
+    }
+
+  &__buy{
+      width: 700px;
+      margin: 0 auto;
+      padding: 24px 12.5% 0;
+      background-color: #fff;
+      text-align: center;
+      border-top: 1px solid #f5f5f5;
+      font-weight: 600;
+
+      &__inner{
+        max-width: 320px;
+        margin: 0 auto;
+        display: flex;
+        flex-wrap: wrap;
+        text-align: center;
+
+        &-item_img  {
+            width: 64px;
+            height: 64px;
+          }
+        &-item_name  {
+          width: calc(100% - 80px);
+          margin: 0 0 0 16px;
+          text-align: left;
+          font-size: 16px;
+          line-height: 1.5;          
+        }
+        
+        &__buying-form{
+          width:100%;
+          margin: 18px 0;
+          display: flex;
+          flex-wrap: wrap;
+          justify-content: center;
+
+            &-price{
+              font-size: 22px;
+            }
+            &-delivery-fee{
+              margin: 5px 0 0 8px;
+              font-size: 14px;
+              font-weight: 400;              
+            }
+            &__pointbox{
+              margin: 18px 0;
+              width: 100%;
+              list-style: none;
+              background: #ccc;
+              
+              li{
+                border: 1px solid #ccc;
+                padding: 16px;
+                font-weight: 400;
+              }
+            }
+            &__payment{
+              margin: 18px 0;
+              width: 100%;
+              list-style: none;
+              
+              &-pay_amount{
+                font-size: 18px;
+                display: flex;
+                flex-wrap: wrap;
+                justify-content: space-between;
+
+                &-price_cell{
+                  font-size:28px;
+                  line-height: 10px;
+                  }
+                }
+              }
+            &-error_text{
+              color: #ea352d;
+              margin: 8px 0 0;
+              line-height: 1.5;
+              font-weight: lighter;
+              }
+            
+            &-btn{
+              display: block;
+              margin: 8px 0 10px;
+              width: 100%;
+              line-height: 45px;
+              border: 1px solid #ccc;
+              background: #ccc;
+              font-size: 14px;
+              font-weight: 200;
+              transition: all ease-out .3s;
+              outline: none;
+              }
+            &-apprecommend{
+              font-weight: 400;
+              line-height: 1.5;
+              }
+            &-app-icon{
+              width: 100%;
+              margin: 15px 0 20px;
+              display: flex;
+              flex-wrap: wrap;
+              justify-content: center;
+
+              &-size-apple{
+                width: 66px;
+                margin: 0 2px;
+              }
+              &-size-google{
+                width: 60px;
+                margin: 0 2px;
+              }
+            }
+            a:hover{
+              text-decoration: underline;
+              opacity: 0.7;
+              }
+              
+            }
+          }
+        }
+
+  &__buyer_info{
+        width: 320px;
+        margin: 0 auto;
+        padding-bottom: 20px;
+        text-align: left;
+
+          h3{
+            font-size: 14px;
+          }
+        &-add{
+          display: block;
+          margin: 8px 0 0;
+          font-size: 14px;
+          font-weight: normal;
+          font-style: normal;
+          line-height: 1.4;
+        }
+        &-change {
+          margin: 10px 0 ;
+          display: block;
+          text-align: right;
+          color: $link;
+          font-weight: normal;
+          text-decoration: none;
+        }
+
+        &-payway{
+          display: block;
+          margin: 8px 0 0;
+          font-size: 14px;
+          font-weight: normal;
+          font-style: normal;
+          line-height: 1.4;
+        }
+
+        .fas{
+          vertical-align: middle;
+          margin: 0 0 0 8px;
+          font-size: 16px;
+        }
+
+        a:hover{
+          text-decoration: underline;
+          opacity: 0.8;
+        }
+
+      }
+  
+
+}

--- a/app/views/funato-newest/top_page.scss
+++ b/app/views/funato-newest/top_page.scss
@@ -1,0 +1,170 @@
+.content{
+  width: 100%;
+  height: 100%;
+  background-color: #f5f5f5;
+  margin: 0;
+  padding: 0;
+
+  .top__header__area{
+    box-sizing: border-box;
+    display: block;
+    height: auto;
+    position: relative;
+    visibility: inherit;
+    width: 100%;
+    background-color: #fff;
+
+    
+    &__carousel{
+      box-sizing: border-box;
+      -moz-box-sizing: border-box;
+      -ms-transform: translate(0, 0);
+      margin: 0px;
+      overflow: hidden;
+      padding: 0;
+      position: relative;
+      touch-action: pinch-zoom pan-y;
+      transform: translate3d(0, 0, 0);
+      -webkit-transform: translate3d(0, 0, 0);
+
+      &-img{
+        width: 100%;
+      }
+    }
+
+    &__popularity{
+      margin: 0 auto 10px;
+      text-align: center;
+      padding-top: 50px;
+
+      &-headline{
+        font-size:28px;
+        font-weight: 600;
+        line-height: 1.4em;
+      }
+
+      &__category{
+        margin: 0 auto;
+        list-style: none;
+        display:flex;
+        flex-direction: row;
+        justify-content: center;
+      
+          li{
+            margin: 10px 7px 30px;
+            padding: 8px 15px;
+            background-color: #e6e6e6;
+            font-weight: bold;
+            cursor: pointer;
+            border-radius: 25px;
+              }
+          }
+        }
+      }
+    
+   .new__items{
+     width: 85%;
+     margin: 15px auto;
+     display: flex;
+     flex-direction: row;
+     justify-content: space-between;
+
+        &-genre{
+          margin: 30px auto 0;
+          width: 100%;
+          display: flex;
+          flex-direction: row;
+          justify-content: space-between;
+
+          h3{
+            font-size: 24px;
+          }
+
+          &-more{
+            font-size: 14px;
+            font-weight: bold;
+            position: relative;
+            vertical-align: middle;
+            
+          }
+          .fas{
+            font-size: 24px;
+            margin-left:10px;
+            vertical-align: middle;
+          }
+
+          a{
+            color: $link;
+            text-decoration: none;
+          }
+        }
+    }
+
+
+      .new__items__container{
+        max-width: 1020px;
+        margin: 0 auto;
+        display: flex;
+        justify-content: space-between;
+        flex-direction: row;
+        flex-wrap:wrap;
+
+        &__box{
+          width: 190px;
+          position: relative;
+          display: flex;
+          flex-direction: column;
+          background-color: #fff;
+          display: -webkit-box;
+          -webkit-box-orient: vertical;
+          -webkit-line-clamp: 2;
+          overflow: hidden;
+          filter:drop-shadow(1px 3px 3px #ccc); 
+          padding-bottom: 5px;
+          
+
+          &-item_phot{
+            width: 190px;
+            height: 190px;
+            }
+
+          &-price {
+            position: absolute;
+            background-color: rgba(0, 0, 0, 0.5);
+            padding: 7px 20px 7px 15px;
+            border-radius: 0 25px 25px 0 ;
+            font-size: 16px;
+            letter-spacing: 1px;
+            color: white;
+            top: 57%;
+            left: 0;
+            }
+
+          &__item_body{
+            padding: 10px 15px;
+            position: relative;
+            line-height: 1.5;
+            letter-spacing: normal; 
+            
+              h3{
+                font-size: 16px;
+                font-weight: lighter;
+              }
+            }
+          } 
+        
+          a{
+            color:#333;
+            text-decoration: none;
+            margin-bottom: 20px;
+          }
+      
+          a:hover{
+            color:#333;
+            text-decoration: none;
+            outline: solid 1px $link ;
+          }
+      }
+       
+}
+    


### PR DESCRIPTION
###Why
商品購入確認ページはユーザーが商品情報を確認するため必要なため。
フロントページの商品一覧の枠がウィンドウサイズによって変わるのを固定に修正。

###What
商品購入確認ページを作成し、フロントの枠の変動を修正した。