### PR TITLE
stepper.jsの修正

### DIFF
--- a/app/assets/javascripts/stepper.js
+++ b/app/assets/javascripts/stepper.js
@@ -1,4 +1,4 @@
-$(function(){
+$(document).on('turbolinks:load', function() {
   if(document.URL.match("/signup/registration")) {
     $('.stepper li').each(function(i, val) {
       $(".stepper li").eq(i).css({'color':'#ea352d','font-weight':'600'})


### PR DESCRIPTION
# What
stepper.jsの修正。

# Why
リンクからsignupページに遷移した時に、jsが発動しない。
そのため、turbolinks:loadを付けて、ページ遷移後もすぐに発動するように修正。