### PR TITLE
Carrierwave設定

### DIFF
--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -1,7 +1,8 @@
 class ImageUploader < CarrierWave::Uploader::Base
   # Include RMagick or MiniMagick support:
   # include CarrierWave::RMagick
-  # include CarrierWave::MiniMagick
+  include CarrierWave::MiniMagick
+  process resize_to_fit: [300, 300]
 
   # Choose what kind of storage to use for this uploader:
   if Rails.env.development? || Rails.env.test?


### PR DESCRIPTION
## What
image_uploader.rbに設定を記述

## Why
画像投稿機能を実装するため

記述内容
  include CarrierWave::MiniMagick
  process resize_to_fit: [200, 200]