### PR TITLE
出品中の商品一覧ページにカレントユーザーでアクセス

### DIFF
--- a/app/controllers/sellings_controller.rb
+++ b/app/controllers/sellings_controller.rb
@@ -1,7 +1,7 @@
 class SellingsController < ApplicationController
 
   def index
-    user = User.find(1)
+    user = User.find(current_user.id)
     @sellings = user.items.page(params[:page]).per(10).order("created_at DESC")
   end
 

--- a/app/views/sellings/index.html.haml
+++ b/app/views/sellings/index.html.haml
@@ -20,7 +20,7 @@
         - @sellings.each do |selling|
           %ul#my-page-selling.sellings-list.tab-pane.active
             %li
-              =link_to "/users/:user_id/sellings/#{selling.id}",{class:"product-link" } do
+              =link_to "/users/#{current_user.id}/sellings/#{selling.id}",{class:"product-link" } do
                 %figure
                   = image_tag selling.images[0].image.url, class: 'product-img'
                 .item-box.show-stock-item


### PR DESCRIPTION
# What
sellingsコントローラーのindexアクションでログイン中のユーザーが持つ出品中の商品一覧ページに遷移できるよう、引数のidにcurrent_user.idを指定
出品中の商品を選択すると、その商品を編集・削除できる画面に遷移できるよう記述
# Why
カレントユーザーが出品した商品はカレントユーザーのみが見る事ができるようにするべきだから