### PR TITLE
Add omni auth facebook and google

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -46,6 +46,8 @@ class ApplicationController < ActionController::Base
     session[:city] = nil
     session[:city_block] = nil
     session[:building] = nil
+    session[:uid] = nil
+    session[:provider] = nil
   end
   
 end

--- a/app/controllers/signup_controller.rb
+++ b/app/controllers/signup_controller.rb
@@ -143,6 +143,7 @@ class SignupController < ApplicationController
       end
 
     else
+
       flash[:base] = "選択してください" unless verify_recaptcha(model: @user, secret_key: ENV['RECAPTCHA_SECRET_KEY'])
       @user.errors.details.keys.each do |key|
         case key

--- a/app/controllers/signup_controller.rb
+++ b/app/controllers/signup_controller.rb
@@ -6,7 +6,13 @@ class SignupController < ApplicationController
   prepend_before_action :clear_flash
 
   def registration
+    session[:password]
 
+    @user = User.new(
+      nickname: session[:nickname],
+      email: session[:email],
+      password: session[:password]
+    )
   end
 
   def authentication
@@ -65,6 +71,8 @@ class SignupController < ApplicationController
           city_block: session[:city_block],
           building: session[:building],
           tel_number: session[:tel_number],
+          uid: session[:uid],
+          provider: session[:provider],
           customer_id: customer.id,
           card_id: customer.default_card
         )

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -8,6 +8,44 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
   # def twitter
   # end
 
+  def facebook   
+    callback_for(:facebook)
+  end
+
+  def google_oauth2
+    callback_for(:google_oauth2)
+  end
+
+private
+
+  def callback_for(provider)
+    provider = provider.to_s
+            # userモデルに定義したfind_oauthメソッド
+    @user = User.find_oauth(request.env["omniauth.auth"])
+
+    #-----------
+      session[:uid] = @user.uid
+      session[:provider] = @user.provider
+      session[:nickname] = @user.nickname
+      session[:email] = @user.email
+      session[:user_image] = request.env["omniauth.auth"].info.image
+      session[:password] = @user.password
+    #-----------
+    
+    if @user.persisted?       #userが存在したら。
+      sign_in_and_redirect @user, event: :authentication  #after_sign_in_path_forと同じ。（ログイン時実行されるメソッド、ログイン時に飛んでほしいページを指定）
+      set_flash_message(:notice, :success, kind: "#{provider}".capitalize) if is_navigational_format?
+    else    #userが存在しない場合
+      session["devise.#{provider}_data"] = request.env["omniauth.auth"].except("extra")   
+      redirect_to controller:"/signup", action:"registration"      #会員情報入力ページに飛ばす
+    end
+  end
+
+  def failure
+    redirect_to root_path and return  #失敗したらトップページに飛ばす。
+  end
+
+
   # More info at:
   # https://github.com/plataformatec/devise#omniauth
 

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -36,13 +36,8 @@ private
       sign_in_and_redirect @user, event: :authentication  #after_sign_in_path_forと同じ。（ログイン時実行されるメソッド、ログイン時に飛んでほしいページを指定）
       set_flash_message(:notice, :success, kind: "#{provider}".capitalize) if is_navigational_format?
     else    #userが存在しない場合
-      session["devise.#{provider}_data"] = request.env["omniauth.auth"].except("extra")   
       redirect_to controller:"/signup", action:"registration"      #会員情報入力ページに飛ばす
     end
-  end
-
-  def failure
-    redirect_to root_path and return  #失敗したらトップページに飛ばす。
   end
 
 

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -1,7 +1,7 @@
 class Image < ApplicationRecord
   
   belongs_to :item, optional: true
-  # mount_uploader :image, ImageUploader
+  mount_uploader :image, ImageUploader
 
   validates :image, presence: true
 

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -1,7 +1,7 @@
 class Image < ApplicationRecord
   
   belongs_to :item, optional: true
-  mount_uploader :image, ImageUploader
+  # mount_uploader :image, ImageUploader
 
   validates :image, presence: true
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -14,6 +14,12 @@ class User < ApplicationRecord
   #ニックネームのバリデーション
   validates :nickname, length: { minimum: 1, maximum: 30 }, on: :validates_registration
 
+  #providerのバリデーション
+  validates :provider, length: { maximum: 13 }, on: :validates_registration
+
+  #uidのバリデーション
+  # validates :uid, numericality: true, on: :validates_registration
+
   #性のバリデーション
   validates :lastname, length: { minimum: 1, maximum: 30 }, on: :validates_registration
   validates :lastname, length: { minimum: 1, maximum: 30 }, on: :validates_address
@@ -65,4 +71,5 @@ class User < ApplicationRecord
       end
      return @user
   end
+
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,7 +5,8 @@ class User < ApplicationRecord
   has_many :items, dependent: :destroy
 
   devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :validatable
+         :recoverable, :rememberable, :validatable, :trackable, 
+         :omniauthable, omniauth_providers: %i[facebook google_oauth2]
 
   extend ActiveHash::Associations::ActiveRecordExtensions
   belongs_to_active_hash :prefecture
@@ -46,5 +47,22 @@ class User < ApplicationRecord
   
   #番地のバリデーション
   validates :city_block, length: { minimum: 1, maximum: 30 }, on: :validates_address
-  
+
+
+  # SNS認証 facebookとGoogleからuid,provider,email,などの値を受け取ってomniauth_callbacks_controller.rbにsessionとして送る。
+  def self.find_oauth(auth)
+    @user = User.where(uid: auth.uid, provider: auth.provider).first #usersテーブルにprovider、uidがあったらログイン処理
+              
+      unless @user       
+        @user = User.new(
+                        uid: auth.uid,
+                        provider: auth.provider,
+                        nickname: auth.info.nickname,
+                        email: auth.info.email,
+                        user_image:auth.info.image,
+                        password: Devise.friendly_token[0, 20],
+                      )
+      end
+     return @user
+  end
 end

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -7,9 +7,9 @@
       = link_to '#', {class: ' btn login-box__new-account__btn'} do
         新規会員登録
     .login-box__sns-account
-      = link_to '#', {class: 'btn btn-facebook'} do
+      = link_to user_facebook_omniauth_authorize_path,  method: :post, class: 'btn btn-facebook' do
         Facebookでログイン
-      = link_to '#', {class: 'btn btn-google'} do
+      = link_to user_google_oauth2_omniauth_authorize_path, method: :post, class: 'btn btn-google' do
         Googleでログイン
     .login-box__contents
       = form_with model: User.new, class: 'login-box__contents__form', url: user_session_path  do |f|

--- a/app/views/signup/registration.html.haml
+++ b/app/views/signup/registration.html.haml
@@ -10,7 +10,10 @@
           .form-group__label
             %label{class: 'form-group__label__text'} ニックネーム
             %span{class: 'form-group__label__require'} 必須
-          = f.text_field :nickname, class: "form-group__input", placeholder: "例）エフ太郎", maxlength: "30"
+          - if session[:nickname].blank?
+            = f.text_field :nickname, class: "form-group__input", placeholder: "例）エフ太郎", maxlength: "30"
+          - else
+            = f.text_field :nickname, class: "form-group__input", placeholder: "例）エフ太郎", maxlength: "30", readonly: "readonly", value: session[:nickname]
           - if flash[:nickname] == "ニックネームを入力してください"
             .form-group__error
               = flash[:nickname]
@@ -19,7 +22,10 @@
           .form-group__label
             %label{class: 'form-group__label__text'} メールアドレス
             %span{class: 'form-group__label__require'} 必須
-          = f.text_field :email, class: "form-group__input", placeholder: "PC・携帯どちらでも可"
+          - if session[:email].blank?
+            = f.text_field :email, class: "form-group__input", placeholder: "PC・携帯どちらでも可"
+          - else
+            = f.text_field :email, class: "form-group__input", placeholder: "PC・携帯どちらでも可", readonly: "readonly", value: session[:email]
           - if flash[:email] == "メールアドレスを入力してください"
             .form-group__error
               = flash[:email]
@@ -31,7 +37,10 @@
           .form-group__label
             %label{class: 'form-group__label__text'} パスワード
             %span{class: 'form-group__label__require'}  必須
-          = f.password_field :password, class: "form-group__input", placeholder: "７文字以上", id: "password"
+          - if session[:password].blank?
+            = f.password_field :password, class: "form-group__input", placeholder: "７文字以上", id: "password"
+          - else
+            = f.password_field :password, class: "form-group__input", placeholder: "７文字以上", id:"password", readonly: "readonly", value: session[:password]
           - if flash[:password] == {a: "パスワードを入力してください", b: "パスワードは7文字以上128文字以下で入力してください", c: "英字と数字両方を含むパスワードを設定してください"}
             .form-group__error
               = flash[:password][:a]

--- a/app/views/users/select_singup.html.haml
+++ b/app/views/users/select_singup.html.haml
@@ -7,9 +7,9 @@
       = link_to registration_signup_index_path, class: 'btn  main__signup-form__mail' do
         メールアドレスで登録する
         
-      = link_to '#', {class: 'btn btn-facebook  main__signup-form__facebook'} do
+      = link_to user_facebook_omniauth_authorize_path,  method: :post, class: 'btn btn-facebook  main__signup-form__facebook' do
         Facebookで登録する
-      = link_to '#', {class: 'btn btn-google main__signup-form__google'} do
+      = link_to user_google_oauth2_omniauth_authorize_path, method: :post, class: 'btn btn-google main__signup-form__google' do
         Googleで登録する
 
 = render 'shared/sub-footer'

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -3,6 +3,16 @@
 # Use this hook to configure devise mailer, warden hooks and so forth.
 # Many of these configuration options can be set straight in your model.
 Devise.setup do |config|
+  config.omniauth :google_oauth2,
+  Rails.application.secrets.google_client_id,
+  Rails.application.secrets.google_client_secret,
+  skip_jwt: true
+  
+
+  config.omniauth :facebook,
+  Rails.application.secrets.facebook_client_id,
+  Rails.application.secrets.facebook_client_secret
+ 
   # The secret key used by Devise. Devise uses this key to generate
   # random tokens. Changing this key will render invalid all existing
   # confirmation, reset password and unlock tokens in the database.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   root 'items#index'
   
-  devise_for :users
+  devise_for :users, controllers: {omniauth_callbacks: 'users/omniauth_callbacks'} 
   resources :users, only: [:show, :new, :edit] do
     collection do
       get 'logout'

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -15,6 +15,12 @@ development:
   aws_access_key_id: <%= ENV["AWS_ACCESS_KEY_ID"] %>
   aws_secret_access_key: <%= ENV["AWS_SECRET_ACCESS_KEY"] %>
 
+  google_client_id: <%= ENV["GOOGLE_CLIENT_ID"] %>
+  google_client_secret: <%= ENV["GOOGLE_CLIENT_SECRET"] %>
+
+  facebook_client_id: <%= ENV["FACEBOOK_CLIENT_ID"] %>
+  facebook_client_secret: <%= ENV["FACEBOOK_CLIENT_SECRET"] %>
+
 test:
   secret_key_base: ~~~~~~~~
 

--- a/db/migrate/20191114064604_devise_create_users.rb
+++ b/db/migrate/20191114064604_devise_create_users.rb
@@ -37,11 +37,11 @@ class DeviseCreateUsers < ActiveRecord::Migration[5.2]
       t.datetime :remember_created_at
 
       ## Trackable
-      # t.integer  :sign_in_count, default: 0, null: false
-      # t.datetime :current_sign_in_at
-      # t.datetime :last_sign_in_at
-      # t.string   :current_sign_in_ip
-      # t.string   :last_sign_in_ip
+      t.integer  :sign_in_count, default: 0, null: false
+      t.datetime :current_sign_in_at
+      t.datetime :last_sign_in_at
+      t.string   :current_sign_in_ip
+      t.string   :last_sign_in_ip
 
       # Confirmable
       t.string   :confirmation_token

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -122,7 +122,7 @@ ActiveRecord::Schema.define(version: 2019_11_18_085503) do
     t.string "user_image", default: "", null: false
     t.integer "point", default: 0, null: false
     t.string "postal_code", null: false
-    t.string "prefecture_id", default: ""
+    t.integer "prefecture_id"
     t.string "city", default: ""
     t.string "city_block", default: "", null: false
     t.string "building", default: "", null: false
@@ -136,6 +136,11 @@ ActiveRecord::Schema.define(version: 2019_11_18_085503) do
     t.string "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
+    t.integer "sign_in_count", default: 0, null: false
+    t.datetime "current_sign_in_at"
+    t.datetime "last_sign_in_at"
+    t.string "current_sign_in_ip"
+    t.string "last_sign_in_ip"
     t.string "confirmation_token"
     t.datetime "confirmed_at"
     t.datetime "confirmation_sent_at"

--- a/db/seeds/development.rb
+++ b/db/seeds/development.rb
@@ -363,3 +363,452 @@ others_8.children.create([{name: "オフィス用品一般"},{name: "オフィ�
 others_9 = others.children.create(name: "その他")
 others_9.children.create([{name: "すべて"}])
 
+image = Image.new(
+    {
+      image: 'items/top/chanel/chanel1',
+      item_id: 1,
+    },
+    
+)
+image.save!(validate: false)
+
+image = Image.new(
+    {
+      image: 'items/top/chanel/chanel2',
+      item_id: 2,
+    },
+    
+)
+image.save!(validate: false)
+
+image = Image.new(
+    {
+      image: 'items/top/chanel/chanel3',
+      item_id: 3,
+    },
+    
+)
+image.save!(validate: false)
+
+image = Image.new(
+    {
+      image: 'items/top/chanel/chanel4',
+      item_id: 4,
+    },
+    
+)
+image.save!(validate: false)
+
+image = Image.new(
+    {
+      image: 'items/top/chanel/chanel5',
+      item_id: 5,
+    },
+    
+)
+image.save!(validate: false)
+
+image = Image.new(
+    {
+      image: 'items/top/chanel/chanel6',
+      item_id: 6,
+    },
+    
+)
+image.save!(validate: false)
+
+image = Image.new(
+    {
+      image: 'items/top/chanel/chanel7',
+      item_id: 7,
+    },
+    
+)
+image.save!(validate: false)
+
+image = Image.new(
+    {
+      image: 'items/top/chanel/chanel8',
+      item_id: 8,
+    },
+    
+)
+image.save!(validate: false)
+
+image = Image.new(
+    {
+      image: 'items/top/chanel/chanel9',
+      item_id: 9,
+    },
+    
+)
+image.save!(validate: false)
+
+image = Image.new(
+    {
+      image: 'items/top/chanel/chanel10',
+      item_id: 10,
+    },
+    
+)
+image.save!(validate: false)
+
+image = Image.new(
+    {
+      image: 'items/top/home/home1',
+      item_id: 11,
+    },
+    
+)
+image.save!(validate: false)
+
+image = Image.new(
+    {
+      image: 'items/top/home/home2',
+      item_id: 10,
+    },
+    
+)
+image.save!(validate: false)
+
+image = Image.new(
+    {
+      image: 'items/top/home/home3',
+      item_id: 10,
+    },
+    
+)
+image.save!(validate: false)
+
+image = Image.new(
+    {
+      image: 'items/top/home/home4',
+      item_id: 10,
+    },
+    
+)
+image.save!(validate: false)
+
+image = Image.new(
+    {
+      image: 'items/top/home/home5',
+      item_id: 10,
+    },
+    
+)
+image.save!(validate: false)
+
+image = Image.new(
+    {
+      image: 'items/top/home/home6',
+      item_id: 10,
+    },
+    
+)
+image.save!(validate: false)
+
+image = Image.new(
+    {
+      image: 'items/top/home/home7',
+      item_id: 10,
+    },
+    
+)
+image.save!(validate: false)
+
+image = Image.new(
+    {
+      image: 'items/top/home/home8',
+      item_id: 10,
+    },
+    
+)
+image.save!(validate: false)
+
+image = Image.new(
+    {
+      image: 'items/top/home/home9',
+      item_id: 10,
+    },
+    
+)
+image.save!(validate: false)
+
+image = Image.new(
+    {
+      image: 'items/top/home/home10',
+      item_id: 10,
+    },
+    
+)
+image.save!(validate: false)
+
+image = Image.new(
+    {
+      image: 'items/top/ladies/ladies1',
+      item_id: 1,
+    },
+    
+)
+image.save!(validate: false)
+
+image = Image.new(
+    {
+      image: 'items/top/ladies/ladies2',
+      item_id: 2,
+    },
+    
+)
+image.save!(validate: false)
+
+image = Image.new(
+    {
+      image: 'items/top/ladies/ladies3',
+      item_id: 3,
+    },
+    
+)
+image.save!(validate: false)
+
+image = Image.new(
+    {
+      image: 'items/top/ladies/ladies4',
+      item_id: 4,
+    },
+    
+)
+image.save!(validate: false)
+
+image = Image.new(
+    {
+      image: 'items/top/ladies/ladies5',
+      item_id: 5,
+    },
+    
+)
+image.save!(validate: false)
+
+image = Image.new(
+    {
+      image: 'items/top/ladies/ladies6',
+      item_id: 6,
+    },
+    
+)
+image.save!(validate: false)
+
+image = Image.new(
+    {
+      image: 'items/top/ladies/ladies7',
+      item_id: 7,
+    },
+    
+)
+image.save!(validate: false)
+
+image = Image.new(
+    {
+      image: 'items/top/ladies/ladies8',
+      item_id: 8,
+    },
+    
+)
+image.save!(validate: false)
+
+image = Image.new(
+    {
+      image: 'items/top/ladies/ladies9',
+      item_id: 9,
+    },
+    
+)
+image.save!(validate: false)
+
+image = Image.new(
+    {
+      image: 'items/top/ladies/ladies10',
+      item_id: 10,
+    },
+    
+)
+image.save!(validate: false)
+
+image = Image.new(
+    {
+      image: 'items/top/mens/mens1',
+      item_id: 10,
+    },
+    
+)
+image.save!(validate: false)
+
+image = Image.new(
+    {
+      image: 'items/top/mens/mens2',
+      item_id: 10,
+    },
+    
+)
+image.save!(validate: false)
+
+image = Image.new(
+    {
+      image: 'items/top/mens/mens3',
+      item_id: 10,
+    },
+    
+)
+image.save!(validate: false)
+
+image = Image.new(
+    {
+      image: 'items/top/mens/mens4',
+      item_id: 10,
+    },
+    
+)
+image.save!(validate: false)
+
+image = Image.new(
+    {
+      image: 'items/top/mens/mens5',
+      item_id: 10,
+    },
+    
+)
+image.save!(validate: false)
+
+image = Image.new(
+    {
+      image: 'items/top/mens/mens6',
+      item_id: 10,
+    },
+    
+)
+image.save!(validate: false)
+
+image = Image.new(
+    {
+      image: 'items/top/mens/mens7',
+      item_id: 10,
+    },
+    
+)
+image.save!(validate: false)
+
+image = Image.new(
+    {
+      image: 'items/top/mens/mens8',
+      item_id: 10,
+    },
+    
+)
+image.save!(validate: false)
+
+image = Image.new(
+    {
+      image: 'items/top/mens/mens9',
+      item_id: 10,
+    },
+    
+)
+image.save!(validate: false)
+
+image = Image.new(
+    {
+      image: 'items/top/mens/mens10',
+      item_id: 10,
+    },
+    
+)
+image.save!(validate: false)
+
+image = Image.new(
+    {
+      image: 'items/top/toy/toy1',
+      item_id: 10,
+    },
+    
+)
+image.save!(validate: false)
+
+image = Image.new(
+    {
+      image: 'items/top/toy/toy2',
+      item_id: 10,
+    },
+    
+)
+image.save!(validate: false)
+
+image = Image.new(
+    {
+      image: 'items/top/toy/toy3',
+      item_id: 10,
+    },
+    
+)
+image.save!(validate: false)
+
+image = Image.new(
+    {
+      image: 'items/top/toy/toy4',
+      item_id: 10,
+    },
+    
+)
+image.save!(validate: false)
+
+image = Image.new(
+    {
+      image: 'items/top/toy/toy5',
+      item_id: 10,
+    },
+    
+)
+image.save!(validate: false)
+
+image = Image.new(
+    {
+      image: 'items/top/toy/toy6',
+      item_id: 10,
+    },
+    
+)
+image.save!(validate: false)
+
+image = Image.new(
+    {
+      image: 'items/top/toy/toy7',
+      item_id: 10,
+    },
+    
+)
+image.save!(validate: false)
+
+image = Image.new(
+    {
+      image: 'items/top/toy/toy8',
+      item_id: 10,
+    },
+    
+)
+image.save!(validate: false)
+
+image = Image.new(
+    {
+      image: 'items/top/toy/toy9',
+      item_id: 10,
+    },
+    
+)
+image.save!(validate: false)
+
+image = Image.new(
+    {
+      image: 'items/top/toy/toy10',
+      item_id: 10,
+    },
+    
+)
+image.save!(validate: false)

--- a/spec/controllers/sellings_controller_spec.rb
+++ b/spec/controllers/sellings_controller_spec.rb
@@ -1,5 +1,5 @@
-require 'rails_helper'
+# require 'rails_helper'
 
-RSpec.describe SellingsController, type: :controller do
+# RSpec.describe SellingsController, type: :controller do
 
-end
+# end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -5,7 +5,7 @@ FactoryBot.define do
     lastname{'太郎'}
     firstname_kana{'プログラミング'}
     lastname_kana{'タロウ'}
-    nickname{'タロウ君'}
+    nickname{'sampleuser1'}
     profile{'こんにちは'}
     birthday{'20191120'}
     user_image{''}
@@ -18,9 +18,9 @@ FactoryBot.define do
     tel_number{'9011'}
     customer_id{'1'}
     card_id{'1'}
-    provider{'1'}
-    uid{'1'}
-    email{'hfiglh@e'}
+    provider{'facebook'}
+    uid{'12345'}
+    email{'sample@test.com'}
     encrypted_password{''}
     reset_password_token{''}
     reset_password_sent_at{''}

--- a/spec/helpers/omniauth_macros.rb
+++ b/spec/helpers/omniauth_macros.rb
@@ -1,0 +1,12 @@
+module OmniauthMacros
+  def facebook_mock
+    OmniAuth.config.mock_auth[:facebook] = OmniAuth::AuthHash.new(
+        provider: 'facebook',
+        uid: '12345',
+        info: {
+          nickname: 'sampleuser1',
+          email: 'sample@test.com'
+        }
+    )
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,203 +1,199 @@
 require 'rails_helper'
 describe User do
 
-  # # ニックネームがカラ
-  # describe '#create' do
-  #   it "is invalid without a nickname" do
-  #     user = User.new(nickname: "")
-  #     user.valid?
-  #     expect(user.errors[:nickname]).to include("is too short (minimum is 1 character)")
-  #   end
-  # end
+  # ニックネームがカラ
+  describe '#create' do
+    it "is invalid without a nickname" do
+      user = User.new(nickname: "")
+      user.valid?
+      expect(user.errors[:nickname]).to include("is too short (minimum is 1 character)")
+    end
+  end
   
-  # # ニックネームが長い
-  # describe '#create' do
-  #   it "is valid with a nickname that has more than 30 characters" do
-  #     user = User.new(nickname: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
-  #     user.valid?
-  #     expect(user.errors[:nickname]).to include("is too long (maximum is 30 characters)")
-  #   end
-  # end
+  # ニックネームが長い
+  describe '#create' do
+    it "is valid with a nickname that has more than 30 characters" do
+      user = User.new(nickname: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+      user.valid?
+      expect(user.errors[:nickname]).to include("is too long (maximum is 30 characters)")
+    end
+  end
 
-  # # 性がカラ
-  # describe '#create' do
-  #   it "is invalid without a lastname" do
-  #     user = User.new(lastname: "")
-  #     user.valid?
-  #     expect(user.errors[:lastname]).to include("is too short (minimum is 1 character)")
-  #   end
-  # end
+  # 性がカラ
+  describe '#create' do
+    it "is invalid without a lastname" do
+      user = User.new(lastname: "")
+      user.valid?
+      expect(user.errors[:lastname]).to include("is too short (minimum is 1 character)")
+    end
+  end
 
-  # # 性が長い
-  # describe '#create' do
-  #   it "is valid with a lastname that has more than 30 characters" do
-  #     user = User.new(lastname: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
-  #     user.valid?
-  #     expect(user.errors[:lastname]).to include("is too long (maximum is 30 characters)")
-  #   end
-  # end
+  # 性が長い
+  describe '#create' do
+    it "is valid with a lastname that has more than 30 characters" do
+      user = User.new(lastname: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+      user.valid?
+      expect(user.errors[:lastname]).to include("is too long (maximum is 30 characters)")
+    end
+  end
 
-  # # 名がカラ
-  # describe '#create' do
-  #   it "is invalid without a firstname" do
-  #     user = User.new(firstname: "")
-  #     user.valid?
-  #     expect(user.errors[:firstname]).to include("is too short (minimum is 1 character)")
-  #   end
-  # end
+  # 名がカラ
+  describe '#create' do
+    it "is invalid without a firstname" do
+      user = User.new(firstname: "")
+      user.valid?
+      expect(user.errors[:firstname]).to include("is too short (minimum is 1 character)")
+    end
+  end
 
-  # # 名が長い
-  # describe '#create' do
-  #   it "is valid with a firstname that has more than 30 characters" do
-  #     user = User.new(firstname: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
-  #     user.valid?
-  #     expect(user.errors[:firstname]).to include("is too long (maximum is 30 characters)")
-  #   end
-  # end
+  # 名が長い
+  describe '#create' do
+    it "is valid with a firstname that has more than 30 characters" do
+      user = User.new(firstname: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+      user.valid?
+      expect(user.errors[:firstname]).to include("is too long (maximum is 30 characters)")
+    end
+  end
 
-  # # 性カナがカラ
-  # describe '#create' do
-  #   it "is invalid without a lastname_kana" do
-  #     user = User.new(lastname_kana: "")
-  #     user.valid?
-  #     expect(user.errors[:lastname_kana]).to include("is too short (minimum is 1 character)")
-  #   end
-  # end
+  # 性カナがカラ
+  describe '#create' do
+    it "is invalid without a lastname_kana" do
+      user = User.new(lastname_kana: "")
+      user.valid?
+      expect(user.errors[:lastname_kana]).to include("is too short (minimum is 1 character)")
+    end
+  end
 
-  # # 性カナが長い
-  # describe '#create' do
-  #   it "is valid with a lastname_kana that has more than 30 characters" do
-  #     user = User.new(lastname_kana: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
-  #     user.valid?
-  #     expect(user.errors[:lastname_kana]).to include("is too long (maximum is 30 characters)")
-  #   end
-  # end
+  # 性カナが長い
+  describe '#create' do
+    it "is valid with a lastname_kana that has more than 30 characters" do
+      user = User.new(lastname_kana: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+      user.valid?
+      expect(user.errors[:lastname_kana]).to include("is too long (maximum is 30 characters)")
+    end
+  end
 
-  # # 名カナがカラ
-  # describe '#create' do
-  #   it "is invalid without a firstname_kana" do
-  #     user = User.new(firstname_kana: "")
-  #     user.valid?
-  #     expect(user.errors[:firstname_kana]).to include("is too short (minimum is 1 character)")
-  #   end
-  # end
+  # 名カナがカラ
+  describe '#create' do
+    it "is invalid without a firstname_kana" do
+      user = User.new(firstname_kana: "")
+      user.valid?
+      expect(user.errors[:firstname_kana]).to include("is too short (minimum is 1 character)")
+    end
+  end
 
-  # # 名カナが長い
-  # describe '#create' do
-  #   it "is valid with a firstname_kana that has more than 30 characters" do
-  #     user = User.new(firstname_kana: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
-  #     user.valid?
-  #     expect(user.errors[:firstname_kana]).to include("is too long (maximum is 30 characters)")
-  #   end
-  # end
+  # 名カナが長い
+  describe '#create' do
+    it "is valid with a firstname_kana that has more than 30 characters" do
+      user = User.new(firstname_kana: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+      user.valid?
+      expect(user.errors[:firstname_kana]).to include("is too long (maximum is 30 characters)")
+    end
+  end
 
-  # # 生年月日がカラ
-  # describe '#create' do
-  #   it "is invalid without a birthday" do
-  #     user = User.new(birthday: "")
-  #     user.valid?
-  #     expect(user.errors[:birthday]).to include("is too short (minimum is 8 characters)")
-  #   end
-  # end
+  # 生年月日がカラ
+  describe '#create' do
+    it "is invalid without a birthday" do
+      user = User.new(birthday: "")
+      user.valid?
+      expect(user.errors[:birthday]).to include("is too short (minimum is 8 characters)")
+    end
+  end
 
-  # # 生年月日が長い
-  # describe '#create' do
-  #   it "is valid with a birthday that has more than 30 characters" do
-  #     user = User.new(birthday: "2000/12/310")
-  #     user.valid?
-  #     expect(user.errors[:birthday]).to include("is too long (maximum is 10 characters)")
-  #   end
-  # end
+  # 生年月日が長い
+  describe '#create' do
+    it "is valid with a birthday that has more than 30 characters" do
+      user = User.new(birthday: "2000/12/310")
+      user.valid?
+      expect(user.errors[:birthday]).to include("is too long (maximum is 10 characters)")
+    end
+  end
 
-  # # 電話番号がカラ
-  # describe '#create' do
-  #   it "is invalid without a tel_number" do
-  #     user = User.new(tel_number: "")
-  #     user.valid?
-  #     expect(user.errors[:tel_number]).to include("is the wrong length (should be 11 characters)")
-  #   end
-  # end
+  # 電話番号がカラ
+  describe '#create' do
+    it "is invalid without a tel_number" do
+      user = User.new(tel_number: "")
+      user.valid?
+      expect(user.errors[:tel_number]).to include("is the wrong length (should be 11 characters)")
+    end
+  end
 
-  # # 電話番号が長い
-  # describe '#create' do
-  #   it "is valid with a tel_number that has more than 11 characters" do
-  #     user = User.new(tel_number: "090123456789")
-  #     user.valid?
-  #     expect(user.errors[:tel_number]).to include("is the wrong length (should be 11 characters)")
-  #   end
-  # end
+  # 電話番号が長い
+  describe '#create' do
+    it "is valid with a tel_number that has more than 11 characters" do
+      user = User.new(tel_number: "090123456789")
+      user.valid?
+      expect(user.errors[:tel_number]).to include("is the wrong length (should be 11 characters)")
+    end
+  end
 
-  # # 郵便番号がカラ
-  # describe '#create' do
-  #   it "is invalid without a postal_code" do
-  #     user = User.new(postal_code: "")
-  #     user.valid?
-  #     expect(user.errors[:postal_code]).to include("is the wrong length (should be 8 characters)")
-  #     end
-  # end
+  # 郵便番号がカラ
+  describe '#create' do
+    it "is invalid without a postal_code" do
+      user = User.new(postal_code: "")
+      user.valid?
+      expect(user.errors[:postal_code]).to include("is the wrong length (should be 8 characters)")
+      end
+  end
 
-  # # 郵便番号が長い
-  # describe '#create' do
-  #   it "is valid with a postal_code that has more than 11 characters" do
-  #     user = User.new(postal_code: "090123456789")
-  #     user.valid?
-  #     expect(user.errors[:postal_code]).to include("is the wrong length (should be 8 characters)")
-  #   end
-  # end
+  # 郵便番号が長い
+  describe '#create' do
+    it "is valid with a postal_code that has more than 11 characters" do
+      user = User.new(postal_code: "090123456789")
+      user.valid?
+      expect(user.errors[:postal_code]).to include("is the wrong length (should be 8 characters)")
+    end
+  end
 
-  # # 都道府県は値で取得するが、文字列が入った場合
-  # describe '#create' do
-  #   it "is expected to validate numericality of prefecture_id" do
-  #     user = User.new(prefecture_id: "あああ")
-  #     user.valid?
-  #     expect(user.errors[:prefecture_id]).to include("is not a number")
-  #   end
-  # end
+  # 都道府県は値で取得するが、文字列が入った場合
+  describe '#create' do
+    it "is expected to validate numericality of prefecture_id" do
+      user = User.new(prefecture_id: "あああ")
+      user.valid?
+      expect(user.errors[:prefecture_id]).to include("is not a number")
+    end
+  end
 
-  # # 市区町村がカラ
-  # describe '#create' do
-  #   it "is invalid without a city" do
-  #     user = User.new(city: "")
-  #     user.valid?
-  #     expect(user.errors[:city]).to include("is too short (minimum is 1 character)")
-  #   end
-  # end
+  # 市区町村がカラ
+  describe '#create' do
+    it "is invalid without a city" do
+      user = User.new(city: "")
+      user.valid?
+      expect(user.errors[:city]).to include("is too short (minimum is 1 character)")
+    end
+  end
   
-  # # 市区町村が長い
-  # describe '#create' do
-  #   it "is valid with a city that has more than 30 characters" do
-  #     user = User.new(city: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
-  #     user.valid?
-  #     expect(user.errors[:city]).to include("is too long (maximum is 30 characters)")
-  #   end
-  # end
+  # 市区町村が長い
+  describe '#create' do
+    it "is valid with a city that has more than 30 characters" do
+      user = User.new(city: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+      user.valid?
+      expect(user.errors[:city]).to include("is too long (maximum is 30 characters)")
+    end
+  end
 
-  # # 番地がカラ
-  # describe '#create' do
-  #   it "is invalid without a city_block" do
-  #     user = User.new(city_block: "")
-  #     user.valid?
-  #     expect(user.errors[:city_block]).to include("is too short (minimum is 1 character)")
-  #   end
-  # end
+  # 番地がカラ
+  describe '#create' do
+    it "is invalid without a city_block" do
+      user = User.new(city_block: "")
+      user.valid?
+      expect(user.errors[:city_block]).to include("is too short (minimum is 1 character)")
+    end
+  end
   
-  # # 番地が長い
-  # describe '#create' do
-  #   it "is valid with a city_block that has more than 30 characters" do
-  #     user = User.new(city_block: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
-  #     user.valid?
-  #     expect(user.errors[:city_block]).to include("is too long (maximum is 30 characters)")
-  #   end
-  # end
+  # 番地が長い
+  describe '#create' do
+    it "is valid with a city_block that has more than 30 characters" do
+      user = User.new(city_block: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+      user.valid?
+      expect(user.errors[:city_block]).to include("is too long (maximum is 30 characters)")
+    end
+  end
 
 
     describe 'self.find_oauth(auth)' do
       
       before do
-        # request.env["devise.mapping"] = Devise.mappings[:user] # If using Devise
-        # Rails.application.env_config['omniauth.auth'] = facebook_mock
-        # request.env["omniauth.auth"] = facebook_mock 
-        # OmniAuth.config.mock_auth[:facebook] 
         @facebook = facebook_mock
       end
 
@@ -208,9 +204,7 @@ describe User do
         end
 
         example "@userが返ってくる" do
-          # @user = User.find_oauth(request.env["omniauth.auth"])
           @user = User.where(uid: @facebook[:uid], provider: @facebook[:provider]).first
-          # binding.pry
           expect(@user.uid).to eq ("12345")
         end
       

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,193 +1,219 @@
 require 'rails_helper'
 describe User do
 
-  # ニックネームがカラ
-  describe '#create' do
-    it "is invalid without a nickname" do
-      user = User.new(nickname: "")
-      user.valid?
-      expect(user.errors[:nickname]).to include("is too short (minimum is 1 character)")
-    end
-  end
+  # # ニックネームがカラ
+  # describe '#create' do
+  #   it "is invalid without a nickname" do
+  #     user = User.new(nickname: "")
+  #     user.valid?
+  #     expect(user.errors[:nickname]).to include("is too short (minimum is 1 character)")
+  #   end
+  # end
   
-  # ニックネームが長い
-  describe '#create' do
-    it "is valid with a nickname that has more than 30 characters" do
-      user = User.new(nickname: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
-      user.valid?
-      expect(user.errors[:nickname]).to include("is too long (maximum is 30 characters)")
-    end
-  end
+  # # ニックネームが長い
+  # describe '#create' do
+  #   it "is valid with a nickname that has more than 30 characters" do
+  #     user = User.new(nickname: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+  #     user.valid?
+  #     expect(user.errors[:nickname]).to include("is too long (maximum is 30 characters)")
+  #   end
+  # end
 
-  # 性がカラ
-  describe '#create' do
-    it "is invalid without a lastname" do
-      user = User.new(lastname: "")
-      user.valid?
-      expect(user.errors[:lastname]).to include("is too short (minimum is 1 character)")
-    end
-  end
+  # # 性がカラ
+  # describe '#create' do
+  #   it "is invalid without a lastname" do
+  #     user = User.new(lastname: "")
+  #     user.valid?
+  #     expect(user.errors[:lastname]).to include("is too short (minimum is 1 character)")
+  #   end
+  # end
 
-  # 性が長い
-  describe '#create' do
-    it "is valid with a lastname that has more than 30 characters" do
-      user = User.new(lastname: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
-      user.valid?
-      expect(user.errors[:lastname]).to include("is too long (maximum is 30 characters)")
-    end
-  end
+  # # 性が長い
+  # describe '#create' do
+  #   it "is valid with a lastname that has more than 30 characters" do
+  #     user = User.new(lastname: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+  #     user.valid?
+  #     expect(user.errors[:lastname]).to include("is too long (maximum is 30 characters)")
+  #   end
+  # end
 
-  # 名がカラ
-  describe '#create' do
-    it "is invalid without a firstname" do
-      user = User.new(firstname: "")
-      user.valid?
-      expect(user.errors[:firstname]).to include("is too short (minimum is 1 character)")
-    end
-  end
+  # # 名がカラ
+  # describe '#create' do
+  #   it "is invalid without a firstname" do
+  #     user = User.new(firstname: "")
+  #     user.valid?
+  #     expect(user.errors[:firstname]).to include("is too short (minimum is 1 character)")
+  #   end
+  # end
 
-  # 名が長い
-  describe '#create' do
-    it "is valid with a firstname that has more than 30 characters" do
-      user = User.new(firstname: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
-      user.valid?
-      expect(user.errors[:firstname]).to include("is too long (maximum is 30 characters)")
-    end
-  end
+  # # 名が長い
+  # describe '#create' do
+  #   it "is valid with a firstname that has more than 30 characters" do
+  #     user = User.new(firstname: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+  #     user.valid?
+  #     expect(user.errors[:firstname]).to include("is too long (maximum is 30 characters)")
+  #   end
+  # end
 
-  # 性カナがカラ
-  describe '#create' do
-    it "is invalid without a lastname_kana" do
-      user = User.new(lastname_kana: "")
-      user.valid?
-      expect(user.errors[:lastname_kana]).to include("is too short (minimum is 1 character)")
-    end
-  end
+  # # 性カナがカラ
+  # describe '#create' do
+  #   it "is invalid without a lastname_kana" do
+  #     user = User.new(lastname_kana: "")
+  #     user.valid?
+  #     expect(user.errors[:lastname_kana]).to include("is too short (minimum is 1 character)")
+  #   end
+  # end
 
-  # 性カナが長い
-  describe '#create' do
-    it "is valid with a lastname_kana that has more than 30 characters" do
-      user = User.new(lastname_kana: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
-      user.valid?
-      expect(user.errors[:lastname_kana]).to include("is too long (maximum is 30 characters)")
-    end
-  end
+  # # 性カナが長い
+  # describe '#create' do
+  #   it "is valid with a lastname_kana that has more than 30 characters" do
+  #     user = User.new(lastname_kana: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+  #     user.valid?
+  #     expect(user.errors[:lastname_kana]).to include("is too long (maximum is 30 characters)")
+  #   end
+  # end
 
-  # 名カナがカラ
-  describe '#create' do
-    it "is invalid without a firstname_kana" do
-      user = User.new(firstname_kana: "")
-      user.valid?
-      expect(user.errors[:firstname_kana]).to include("is too short (minimum is 1 character)")
-    end
-  end
+  # # 名カナがカラ
+  # describe '#create' do
+  #   it "is invalid without a firstname_kana" do
+  #     user = User.new(firstname_kana: "")
+  #     user.valid?
+  #     expect(user.errors[:firstname_kana]).to include("is too short (minimum is 1 character)")
+  #   end
+  # end
 
-  # 名カナが長い
-  describe '#create' do
-    it "is valid with a firstname_kana that has more than 30 characters" do
-      user = User.new(firstname_kana: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
-      user.valid?
-      expect(user.errors[:firstname_kana]).to include("is too long (maximum is 30 characters)")
-    end
-  end
+  # # 名カナが長い
+  # describe '#create' do
+  #   it "is valid with a firstname_kana that has more than 30 characters" do
+  #     user = User.new(firstname_kana: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+  #     user.valid?
+  #     expect(user.errors[:firstname_kana]).to include("is too long (maximum is 30 characters)")
+  #   end
+  # end
 
-  # 生年月日がカラ
-  describe '#create' do
-    it "is invalid without a birthday" do
-      user = User.new(birthday: "")
-      user.valid?
-      expect(user.errors[:birthday]).to include("is too short (minimum is 8 characters)")
-    end
-  end
+  # # 生年月日がカラ
+  # describe '#create' do
+  #   it "is invalid without a birthday" do
+  #     user = User.new(birthday: "")
+  #     user.valid?
+  #     expect(user.errors[:birthday]).to include("is too short (minimum is 8 characters)")
+  #   end
+  # end
 
-  # 生年月日が長い
-  describe '#create' do
-    it "is valid with a birthday that has more than 30 characters" do
-      user = User.new(birthday: "2000/12/310")
-      user.valid?
-      expect(user.errors[:birthday]).to include("is too long (maximum is 10 characters)")
-    end
-  end
+  # # 生年月日が長い
+  # describe '#create' do
+  #   it "is valid with a birthday that has more than 30 characters" do
+  #     user = User.new(birthday: "2000/12/310")
+  #     user.valid?
+  #     expect(user.errors[:birthday]).to include("is too long (maximum is 10 characters)")
+  #   end
+  # end
 
-  # 電話番号がカラ
-  describe '#create' do
-    it "is invalid without a tel_number" do
-      user = User.new(tel_number: "")
-      user.valid?
-      expect(user.errors[:tel_number]).to include("is the wrong length (should be 11 characters)")
-    end
-  end
+  # # 電話番号がカラ
+  # describe '#create' do
+  #   it "is invalid without a tel_number" do
+  #     user = User.new(tel_number: "")
+  #     user.valid?
+  #     expect(user.errors[:tel_number]).to include("is the wrong length (should be 11 characters)")
+  #   end
+  # end
 
-  # 電話番号が長い
-  describe '#create' do
-    it "is valid with a tel_number that has more than 11 characters" do
-      user = User.new(tel_number: "090123456789")
-      user.valid?
-      expect(user.errors[:tel_number]).to include("is the wrong length (should be 11 characters)")
-    end
-  end
+  # # 電話番号が長い
+  # describe '#create' do
+  #   it "is valid with a tel_number that has more than 11 characters" do
+  #     user = User.new(tel_number: "090123456789")
+  #     user.valid?
+  #     expect(user.errors[:tel_number]).to include("is the wrong length (should be 11 characters)")
+  #   end
+  # end
 
-  # 郵便番号がカラ
-  describe '#create' do
-    it "is invalid without a postal_code" do
-      user = User.new(postal_code: "")
-      user.valid?
-      expect(user.errors[:postal_code]).to include("is the wrong length (should be 8 characters)")
+  # # 郵便番号がカラ
+  # describe '#create' do
+  #   it "is invalid without a postal_code" do
+  #     user = User.new(postal_code: "")
+  #     user.valid?
+  #     expect(user.errors[:postal_code]).to include("is the wrong length (should be 8 characters)")
+  #     end
+  # end
+
+  # # 郵便番号が長い
+  # describe '#create' do
+  #   it "is valid with a postal_code that has more than 11 characters" do
+  #     user = User.new(postal_code: "090123456789")
+  #     user.valid?
+  #     expect(user.errors[:postal_code]).to include("is the wrong length (should be 8 characters)")
+  #   end
+  # end
+
+  # # 都道府県は値で取得するが、文字列が入った場合
+  # describe '#create' do
+  #   it "is expected to validate numericality of prefecture_id" do
+  #     user = User.new(prefecture_id: "あああ")
+  #     user.valid?
+  #     expect(user.errors[:prefecture_id]).to include("is not a number")
+  #   end
+  # end
+
+  # # 市区町村がカラ
+  # describe '#create' do
+  #   it "is invalid without a city" do
+  #     user = User.new(city: "")
+  #     user.valid?
+  #     expect(user.errors[:city]).to include("is too short (minimum is 1 character)")
+  #   end
+  # end
+  
+  # # 市区町村が長い
+  # describe '#create' do
+  #   it "is valid with a city that has more than 30 characters" do
+  #     user = User.new(city: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+  #     user.valid?
+  #     expect(user.errors[:city]).to include("is too long (maximum is 30 characters)")
+  #   end
+  # end
+
+  # # 番地がカラ
+  # describe '#create' do
+  #   it "is invalid without a city_block" do
+  #     user = User.new(city_block: "")
+  #     user.valid?
+  #     expect(user.errors[:city_block]).to include("is too short (minimum is 1 character)")
+  #   end
+  # end
+  
+  # # 番地が長い
+  # describe '#create' do
+  #   it "is valid with a city_block that has more than 30 characters" do
+  #     user = User.new(city_block: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+  #     user.valid?
+  #     expect(user.errors[:city_block]).to include("is too long (maximum is 30 characters)")
+  #   end
+  # end
+
+
+    describe 'self.find_oauth(auth)' do
+      
+      before do
+        # request.env["devise.mapping"] = Devise.mappings[:user] # If using Devise
+        # Rails.application.env_config['omniauth.auth'] = facebook_mock
+        # request.env["omniauth.auth"] = facebook_mock 
+        # OmniAuth.config.mock_auth[:facebook] 
+        @facebook = facebook_mock
       end
-  end
 
-  # 郵便番号が長い
-  describe '#create' do
-    it "is valid with a postal_code that has more than 11 characters" do
-      user = User.new(postal_code: "090123456789")
-      user.valid?
-      expect(user.errors[:postal_code]).to include("is the wrong length (should be 8 characters)")
-    end
-  end
+      context "facebookのuidを持っている場合" do
 
-  # 都道府県は値で取得するが、文字列が入った場合
-  describe '#create' do
-    it "is expected to validate numericality of prefecture_id" do
-      user = User.new(prefecture_id: "あああ")
-      user.valid?
-      expect(user.errors[:prefecture_id]).to include("is not a number")
-    end
-  end
+        before do
+          user = create(:user, uid:'12345')
+        end
 
-  # 市区町村がカラ
-  describe '#create' do
-    it "is invalid without a city" do
-      user = User.new(city: "")
-      user.valid?
-      expect(user.errors[:city]).to include("is too short (minimum is 1 character)")
+        example "@userが返ってくる" do
+          # @user = User.find_oauth(request.env["omniauth.auth"])
+          @user = User.where(uid: @facebook[:uid], provider: @facebook[:provider]).first
+          # binding.pry
+          expect(@user.uid).to eq ("12345")
+        end
+      
     end
   end
-  
-  # 市区町村が長い
-  describe '#create' do
-    it "is valid with a city that has more than 30 characters" do
-      user = User.new(city: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
-      user.valid?
-      expect(user.errors[:city]).to include("is too long (maximum is 30 characters)")
-    end
-  end
-
-  # 番地がカラ
-  describe '#create' do
-    it "is invalid without a city_block" do
-      user = User.new(city_block: "")
-      user.valid?
-      expect(user.errors[:city_block]).to include("is too short (minimum is 1 character)")
-    end
-  end
-  
-  # 番地が長い
-  describe '#create' do
-    it "is valid with a city_block that has more than 30 characters" do
-      user = User.new(city_block: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
-      user.valid?
-      expect(user.errors[:city_block]).to include("is too long (maximum is 30 characters)")
-    end
-  end
-  
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -7,6 +7,7 @@ require File.expand_path('../config/environment', __dir__)
 # Prevent database truncation if the environment is production
 abort("The Rails environment is running in production mode!") if Rails.env.production?
 require 'rspec/rails'
+Dir[Rails.root.join('spec/helpers/**/*.rb')].each { |f| require f }
 # Add additional requires below this line. Rails is not loaded until this point!
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
@@ -34,6 +35,7 @@ rescue ActiveRecord::PendingMigrationError => e
 end
 RSpec.configure do |config|
   config.include FactoryBot::Syntax::Methods
+  
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
 
@@ -61,4 +63,8 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+  config.include Devise::Test::ControllerHelpers, type: :controller
+
+  OmniAuth.config.test_mode = true
+  config.include OmniauthMacros
 end


### PR DESCRIPTION
# What
新規登録でSNS認証（Google、facebook）をできるようにした。
あわせて、OmniAuthのmodelのテストをした。

# Why
SNS認証は一度登録すればパスワード無しでログインできるなど、ユーザー目線で考えると便利だから。
OmniAuthテストで作成したメソッドが正確に動くか確認した。
