### PR TITLE
fixed devise.rb for sns access

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -6,8 +6,6 @@ Devise.setup do |config|
   config.omniauth :google_oauth2, ENV['GOOGLE_CLIENT_ID'], ENV['GOOGLE_CLIENT_SECRET'], skip_jwt: true
   # Rails.application.secrets.google_client_id,
   # Rails.application.secrets.google_client_secret,
-  
-  
 
   config.omniauth :facebook, ENV['FACEBOOK_CLIENT_ID'], ENV['FACEBOOK_CLIENT_SECRET']
   # Rails.application.secrets.facebook_client_id,


### PR DESCRIPTION
# What
config/initializers/devise.rbのfacebook認証のキーを修正した。

# Why
記述間違いのため。