### PR TITLE
ページ制限

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,11 @@
 class ApplicationController < ActionController::Base
   before_action :basic_auth, if: :production?
+  before_action :authenticate_user!
   protect_from_forgery with: :exception
+
+  def after_sign_in_path_for(resource)
+    items_path
+  end
 
   private
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
+  skip_before_action :authenticate_user!, only: [:index, :show]
   before_action :set_submodel, only: [:new, :create, :edit, :update]
-  before_action :move_to_sign_in, except: [:index, :show]
 
   def index
     @ladies_ids = Category.find(1).subtree_ids
@@ -162,11 +162,6 @@ class ItemsController < ApplicationController
     @delivery_methods = DeliveryMethod.all
     @delivery_fee = ['着払い','送料込み']
   end
-
-  def move_to_sign_in
-    redirect_to controller: 'devise/sessions', action: 'new' unless user_signed_in?
-  end
-
 
 end
 

--- a/app/controllers/signup_controller.rb
+++ b/app/controllers/signup_controller.rb
@@ -1,4 +1,5 @@
 class SignupController < ApplicationController
+  skip_before_action :authenticate_user!
   before_action :validates_registration, only: :authentication
   before_action :validates_authentication, only: :address
   before_action :validates_address, only: :credit

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,6 @@
 class UsersController < ApplicationController
-
+  skip_before_action :authenticate_user!, only: :select_singup
+  before_action  :clear_session, only: :select_singup
 
   def show
     @user = User.find(current_user.id)

--- a/app/views/shared/_post.html.haml
+++ b/app/views/shared/_post.html.haml
@@ -1,13 +1,6 @@
 .post
-  - if user_signed_in?
-    = link_to new_item_path do
-      .post__text
-        出品
-      .post__camera
-        = fa_icon 'camera 4x'
-  - else
-    = link_to new_user_session_path do
-      .post__text
-        出品
-      .post__camera
-        = fa_icon 'camera 4x'
+  = link_to new_item_path do
+    .post__text
+      出品
+    .post__camera
+      = fa_icon 'camera 4x'


### PR DESCRIPTION
# What
ログインしていないユーザーが、トップページと商品詳細ページ、会員登録、ログイン以外のページにアクセスできないようにした。

# Why
ログインユーザー以外がアクセスしてしまうと不具合が起きるため。

例えば、商品購入ページにログインユーザー以外がアクセスできると商品を購入することができるため。