### PR TITLE
edit items_controller for avoiding own item link when current_user

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -53,7 +53,14 @@ class ItemsController < ApplicationController
   end
   
   def show
-    @item = Item.find(params[:id])
+    @item = Item.find(params[:id]) 
+    if current_user.present?
+      if @item.user.id == current_user.id
+      redirect_to action: 'index'
+      else
+      @item = Item.find(params[:id]) 
+      end
+    end
   end
   
   def update
@@ -90,13 +97,21 @@ class ItemsController < ApplicationController
   end
 
   def confirmation
-    if user_signed_in?
-      Payjp.api_key = ENV['PAYJP_API_KEY']
-      @item = Item.find(params[:id])
-      customer = Payjp::Customer.retrieve(current_user.customer_id)
-      @card_information = customer.cards.retrieve(current_user.card_id)
-    else
-      redirect_to new_user_session_path
+    if current_user.present?
+      if @item = Item.find(params[:id])
+        if @item[:user_id] == current_user.id
+        redirect_to action: 'index'
+        else
+        if user_signed_in?
+          Payjp.api_key = ENV['PAYJP_API_KEY']
+          @item = Item.find(params[:id])
+          customer = Payjp::Customer.retrieve(current_user.customer_id)
+          @card_information = customer.cards.retrieve(current_user.card_id)
+        else
+          redirect_to new_user_session_path
+          end
+        end
+      end
     end
   end
 


### PR DESCRIPTION
# What
items_controllerを編集した。
・ログイン中のcurrent_userが自身で投稿した商品をクリックした場合、商品詳細ページに飛ばずトップページにリダイレクトされるように変更。アドレスを直打ちしてもトップページへリダイレクトされるようにした。
・ログイン中のcurrent_userが自身で投稿した商品の購入確認ページへ行けなくした。アドレスを直打ちした場合、トップページにリダイレクトされる仕様。

# Why
自分で出品した商品を購入できる状況はシステム上、求められていないから。
