### PR TITLE
商品詳細ページのビュー修正

### DIFF
--- a/app/assets/stylesheets/items/_show.scss
+++ b/app/assets/stylesheets/items/_show.scss
@@ -18,7 +18,7 @@
 
   &__box{
     width: 620px;
-    height: 420px;
+    height: 449px;
     display: flex;
     flex-direction: row;
     font-family: '游ゴシック体', 'YuGothic', sans-serif;
@@ -28,7 +28,7 @@
       position: relative;
       min-width: 300px;
       max-width: 300px;
-      height: 100%;
+      height: 420px;
       background-color: $main;
       }
 
@@ -60,7 +60,7 @@
      &__details-area{
        float: right;
         width: 300px;
-        height: 420px;
+        height: 450px;
         margin: 0 0 0 20px;
          }  
 


### PR DESCRIPTION
# What
商品詳細ページのビューの崩れを修正
# Why
カテゴリーの文字数が多く改行された場合に商品詳細ページの価格と商品説明のボックスが被っていた為